### PR TITLE
feat: Save and move files related to the final document

### DIFF
--- a/src/laudo/laudo.service.ts
+++ b/src/laudo/laudo.service.ts
@@ -5,12 +5,17 @@ import {
   createReadStream,
   existsSync,
   ReadStream,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from 'fs';
 import { join } from 'path';
 import { PrismaService } from 'src/prisma.service';
-import { DirsHandler, LAUDOS_DIR } from 'src/project_structure/dirs';
+import {
+  DirsHandler,
+  LAUDOS_DIR,
+  SCRIPTS_DIR,
+} from 'src/project_structure/dirs';
 import { listScriptsDir, ProjUtils } from 'src/project_utils/utils';
 import { CreateLaudoDto } from './dto/create-laudo.dto';
 import { getFinalDocument } from './tabelas/documentoFinal';
@@ -241,6 +246,7 @@ export class LaudoService {
       estado: hospital.estado,
       numeroProcesso: ProjUtils.Unwrap(laudo.numero_processo),
       dataDistribuicao: data,
+      file_name: laudo.file_name,
     });
 
     // Salva o arquivo .tex
@@ -273,6 +279,11 @@ export class LaudoService {
       if (existsSync(auxFile)) {
         unlinkSync(auxFile);
       }
+    });
+
+    rmSync(join(SCRIPTS_DIR, `H${hospital.cnes}${hospital.estado}`), {
+      recursive: true,
+      force: true,
     });
 
     console.log(`PDF gerado com sucesso em: ${pdfPath}`);

--- a/src/laudo/tabelas/documentoFinal.ts
+++ b/src/laudo/tabelas/documentoFinal.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
+import { copyFileSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { getresumoAnual } from './anual';
 import { getfilesPA } from './arquivosPA';
@@ -9,6 +9,7 @@ import { getMensal } from './mensal';
 import { getProcedimentoAcumulado } from './procedimentoAcumulado';
 import { getresumoMes } from './resumoMes';
 import { getResumoTotal } from './resumoTotal';
+import { LAUDOS_DIR } from 'src/project_structure/dirs';
 
 export interface finalDocParams {
   razaoSocial: string;
@@ -19,6 +20,7 @@ export interface finalDocParams {
   estado: string;
   numeroProcesso: string;
   dataDistribuicao: string;
+  file_name: string;
 }
 
 export function getFinalDocument(params: finalDocParams): string[] {
@@ -41,6 +43,18 @@ export function getFinalDocument(params: finalDocParams): string[] {
   // Ler o arquivo CSV
   const csv_arquivossp = readFileSync(pathToData('amostra_sp.csv'), 'utf-8');
   const csv_arquivospa = readFileSync(pathToData('amostra_pa.csv'), 'utf-8');
+
+  // mover as amostras para a pasta de laudos
+  copyFileSync(
+    pathToData('amostra_sp.csv'),
+    join(LAUDOS_DIR, `PA${params.cnes}${params.file_name}.csv`),
+  );
+
+  // mover as amostras para a pasta de laudos
+  copyFileSync(
+    pathToData('amostra_pa.csv'),
+    join(LAUDOS_DIR, `SP${params.cnes}${params.file_name}.csv`),
+  );
 
   const csv_individualizada = readFileSync(
     pathToData('calculo_IVR_TUNEP_individualizado.csv'),


### PR DESCRIPTION
- Save the file name in the database. - Move the sample files to the laudos directory. - Remove the script directory after generating the PDF.